### PR TITLE
Change updateText method when using IE WebDriver

### DIFF
--- a/src/main/java/noraui/application/steps/Step.java
+++ b/src/main/java/noraui/application/steps/Step.java
@@ -38,6 +38,7 @@ import cucumber.runtime.java.StepDefAnnotation;
 import noraui.application.page.IPage;
 import noraui.application.page.Page;
 import noraui.application.page.Page.PageElement;
+import noraui.browser.DriverFactory;
 import noraui.browser.steps.BrowserSteps;
 import noraui.cucumber.annotation.Conditioned;
 import noraui.cucumber.injector.NoraUiInjector;
@@ -186,8 +187,13 @@ public class Step implements IStep {
                 String value = Context.getValue(textOrKey) != null ? Context.getValue(textOrKey) : textOrKey;
                 WebElement element = Context.waitUntil(ExpectedConditions.elementToBeClickable(Utilities.getLocator(pageElement, args)));
                 element.clear();
-                element.sendKeys(value);
-                if (keysToSend != null) {
+                if (DriverFactory.IE.equals(Context.getBrowser())) {
+                	 String javascript = "arguments[0].value='" + textOrKey + "';";
+                	((JavascriptExecutor) getDriver()).executeScript(javascript, element);
+                } else {
+                	element.sendKeys(value);
+                }
+            	if (keysToSend != null) {
                     element.sendKeys(keysToSend);
                 }
             } catch (Exception e) {


### PR DESCRIPTION
In my project, i had to update a text field with a full XML Flow.

It worked perfectly using Chrome. But when i use IE, only a few of the first characters of the flow were updated in the field. I supposed it was due for the IE WebDriver taking too much time to taking into consideration all the caracters to type using sendKeys() method. Using a javascript one resolved this issue for me.

And the sendKeys() method is still extremely slow compared to the javascript one, i think it is a better idea to use the javascript method in IE rather than the sendKeys() one.