### PR TITLE
issue #6: Loading class `com.mysql.jdbc.Driver' deprecated.

### DIFF
--- a/src/main/java/noraui/data/db/DBDataProvider.java
+++ b/src/main/java/noraui/data/db/DBDataProvider.java
@@ -35,7 +35,7 @@ public class DBDataProvider extends CommonDataProvider implements DataInputProvi
         this.password = password;
         try {
             if (types.MYSQL.toString().equals(type)) {
-                Class.forName("com.mysql.jdbc.Driver");
+                Class.forName("com.mysql.cj.jdbc.Driver");
                 this.connectionUrl = "jdbc:mysql://" + hostname + ":" + port + "/" + database;
             } else if (types.ORACLE.toString().equals(type)) {
                 Class.forName("oracle.jdbc.OracleDriver");

--- a/src/main/java/noraui/data/db/DBDataProvider.java
+++ b/src/main/java/noraui/data/db/DBDataProvider.java
@@ -183,6 +183,7 @@ public class DBDataProvider extends CommonDataProvider implements DataInputProvi
         } catch (SQLException e) {
             throw new TechnicalException(TechnicalException.TECHNICAL_ERROR_MESSAGE + e.getMessage(), e);
         }
+        resultColumnName = ResultColumnNames.getAuthorizedNames().get(0);
     }
 
     protected static void sqlSanitized4readOnly(String sqlInput) throws TechnicalException {

--- a/src/main/java/noraui/data/db/DBDataProvider.java
+++ b/src/main/java/noraui/data/db/DBDataProvider.java
@@ -36,7 +36,7 @@ public class DBDataProvider extends CommonDataProvider implements DataInputProvi
         try {
             if (types.MYSQL.toString().equals(type)) {
                 Class.forName("com.mysql.cj.jdbc.Driver");
-                this.connectionUrl = "jdbc:mysql://" + hostname + ":" + port + "/" + database;
+                this.connectionUrl = "jdbc:mysql://" + hostname + ":" + port + "/" + database + "?useSSL=false&serverTimezone=UTC";
             } else if (types.ORACLE.toString().equals(type)) {
                 Class.forName("oracle.jdbc.OracleDriver");
                 this.connectionUrl = "jdbc:oracle:thin:@" + hostname + ":" + port + ":" + database;


### PR DESCRIPTION
Loading class `com.mysql.jdbc.Driver'. This is deprecated. The new driver class is `com.mysql.cj.jdbc.Driver'. The driver is automatically registered via the SPI and manual loading of the driver class is generally unnecessary.