### PR TITLE
fix issue #36

### DIFF
--- a/src/main/java/com/github/noraui/application/steps/ExpectSteps.java
+++ b/src/main/java/com/github/noraui/application/steps/ExpectSteps.java
@@ -74,7 +74,7 @@ public class ExpectSteps extends Step {
                 try {
                     WebElement element = driver.findElement(locator);
                     if (element != null && value != null) {
-                        return !((element.getAttribute(VALUE) == null || !value.equals(element.getAttribute(VALUE).trim())) && !value.equals(element.getText()));
+                        return !((element.getAttribute(VALUE) == null || !value.equals(element.getAttribute(VALUE).trim())) && !value.equals(element.getText().replaceAll("\n", "")));
                     }
                 } catch (Exception e) {
                 }


### PR DESCRIPTION
`<br>` change `by` \n in `org.openqa.selenium.WebElement.getText()`

Official getText() javadoc : Get the visible (i.e. not hidden by CSS) innerText of this element, including sub-elements, without any leading or trailing whitespace.