### PR TITLE
change Failure by Warning when TechnicalException

### DIFF
--- a/src/main/java/com/github/noraui/application/steps/CommonSteps.java
+++ b/src/main/java/com/github/noraui/application/steps/CommonSteps.java
@@ -336,8 +336,7 @@ public class CommonSteps extends Step {
             try {
                 Context.getDataOutputProvider().writeDataResult(targetColumn, line, value);
             } catch (final TechnicalException e) {
-                new Result.Failure<>(e.getMessage(), Messages.format(Messages.getMessage(Messages.FAIL_MESSAGE_UNABLE_TO_WRITE_MESSAGE_IN_RESULT_FILE), targetColumn), true,
-                        Page.getInstance(page).getCallBack());
+                new Result.Warning<>(e.getMessage(), Messages.format(Messages.getMessage(Messages.FAIL_MESSAGE_UNABLE_TO_WRITE_MESSAGE_IN_RESULT_FILE), targetColumn), false, 0);
             }
         }
     }

--- a/test/run.sh
+++ b/test/run.sh
@@ -53,7 +53,7 @@ cd ..
 if [ "$TRAVIS_REPO_SLUG" == 'NoraUi/NoraUi' ] && [ "$TRAVIS_BRANCH" == 'master' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
     mvn -e -U clean org.jacoco:jacoco-maven-plugin:prepare-agent package javadoc:javadoc sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=noraui -Dsonar.login=$SONAR_TOKEN -Dcucumber.options="--tags '@hello or @bonjour or @blog or @playToLogoGame or @jouerAuJeuDesLogos'" -PscenarioInitiator,javadoc,unit-tests --settings test/mvnsettings.xml -Dmaven.test.failure.ignore=true -Dcrypto.key=${CRYPTO_KEY}
 else
-    mvn -e -U clean package javadoc:javadoc -Dpullrequest -Dcucumber.options="--tags '@hello or @bonjour or @blog or @playToLogoGame or @jouerAuJeuDesLogos'" -PscenarioInitiator,javadoc,unit-tests --settings test/mvnsettings.xml -Dmaven.test.failure.ignore=true -Dcrypto.key=${CRYPTO_KEY}
+    mvn -e -U clean package javadoc:javadoc -Dpullrequest -Dcucumber.options="--tags '@hello or @bonjour or @blog or @playToLogoGame or @jouerAuJeuDesLogos'" -PscenarioInitiator,javadoc,unit-tests --settings test/mvnsettings.xml -Dmaven.test.failure.ignore=true -Dcrypto.key=my-secret
 fi
 
 #


### PR DESCRIPTION
change Result.Failure by Result.Warning when TechnicalException 

if  Context.getDataOutputProvider().writeDataResult(targetColumn, line, value); throws an TechnicalException I think a Result.Warning is better than Result.Failure ??