### PR TITLE
Sonar: Arrays should not be copied using loops

### DIFF
--- a/src/main/java/com/github/noraui/data/csv/CsvDataProvider.java
+++ b/src/main/java/com/github/noraui/data/csv/CsvDataProvider.java
@@ -112,9 +112,7 @@ public class CsvDataProvider extends CommonDataProvider implements DataInputProv
                 return null;
             } else {
                 final String[] ret = readResult ? new String[columns.size()] : new String[columns.size() - 1];
-                for (int i = 0; i < ret.length; i++) {
-                    ret[i] = row[i];
-                }
+                System.arraycopy(row, 0, ret, 0, ret.length);
                 return ret;
             }
         } catch (final IOException e) {


### PR DESCRIPTION
Using a loop to copy an array or a subset of an array is simply wasted code when there are built-in functions to do it for you. Instead, use Arrays.copyOf to copy an entire array into another array, use System.arraycopy to copy only a subset of an array into another array, and use Arrays.asList to feed the constructor of a new list with an array.

Note that Arrays.asList simply puts a Collections wrapper around the original array, so further steps are required if a non-fixed-size List is desired.

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

<!--- Provide a general summary description of your changes -->

## Details

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
