### PR TITLE
Arrays should not be copied using loops

### DIFF
--- a/src/main/java/com/github/noraui/data/gherkin/InputGherkinDataProvider.java
+++ b/src/main/java/com/github/noraui/data/gherkin/InputGherkinDataProvider.java
@@ -125,9 +125,7 @@ public class InputGherkinDataProvider extends CommonDataProvider implements Data
 		columns = new ArrayList<>();
 		if (examples.length > 1) {
 			final String[] cols = examples[0].split("\\|", -1);
-			for (int i = 1; i < cols.length - 1; i++) {
-				columns.add(cols[i]);
-			}
+			System.arraycopy(cols, 0, columns, 0, cols.length);
 		} else {
 			throw new EmptyDataFileContentException(
 					Messages.getMessage(EmptyDataFileContentException.EMPTY_DATA_FILE_CONTENT_ERROR_MESSAGE));


### PR DESCRIPTION
Using a loop to copy an array or a subset of an array is simply wasted code when there are built-in functions to do it for you. Instead, use Arrays.copyOf to copy an entire array into another array, use System.arraycopy to copy only a subset of an array into another array, and use Arrays.asList to feed the constructor of a new list with an array.

Note that Arrays.asList simply puts a Collections wrapper around the original array, so further steps are required if a non-fixed-size List is desired.

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

<!--- Provide a general summary description of your changes -->

## Details

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
